### PR TITLE
Update opentelemetry version

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "nyholm/psr7": "^1.5",
         "spiral/roadrunner": "v2.10",
-        "open-telemetry/opentelemetry": ">=0.0.10",
+        "open-telemetry/opentelemetry": ">=0.0.17",
         "monolog/monolog": "~3",
         "php-http/guzzle6-adapter": "~2"
     }

--- a/src/index.php
+++ b/src/index.php
@@ -16,8 +16,8 @@ $psrFactory = new Psr7\Factory\Psr17Factory();
 $logger = new Logger('otel-php', [new StreamHandler(STDERR, LogLevel::DEBUG)]);
 LoggerHolder::set($logger);
 
-$tracerProvider = (new TracerProviderFactory('example'))->create();
-$tracer = $tracerProvider->getTracer();
+$tracerProvider = (new TracerProviderFactory())->create();
+$tracer = $tracerProvider->getTracer('example');
 
 $worker = new RoadRunner\Http\PSR7Worker($worker, $psrFactory, $psrFactory, $psrFactory);
 


### PR DESCRIPTION
Noticed the demo did not work "out of the box" due to a change in constructor signature in the opentelemetry `TracerProviderFactory`.

This PR:
* Updates `open-telemetry/opentelemetry` to a minimum version 0.0.17
* Relevant minor `index.php` changes